### PR TITLE
Encode url before create tinyurl.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var request = require('request');
 
 module.exports = {
     shorten: function(url, cb) {
-        request('http://tinyurl.com/api-create.php?url=' + url, function (error, response, body) {
+        request('http://tinyurl.com/api-create.php?url=' + encodeURIComponent(url), function (error, response, body) {
 			cb(body.split("\n")[0]);
         });
     }


### PR DESCRIPTION
When the url have # the tinyurl is only the host. 
Example:
http://test-server:8080/#/test/Z4zm4OuFTqiE5Fw46m4fdA
The tinyurl decoded will be :  http://test-server:8080

With the encoded url all url works.
