### PR TITLE
Implement link resolver function

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,5 +21,27 @@ module.exports = {
 				})
 			})
 		}
-	}
+	},
+	resolve: function(url, cb) {
+		if (typeof cb === "function")
+		  http
+			.get(url, res => {
+			  if (res.headers.location) cb(res.headers.location);
+			  else cb(null, new Error("Tiny URL not found!"));
+			})
+			.on("error", err => {
+			  cb(null, err);
+			});
+		else
+		  return new Promise((resolve, reject) => {
+			http
+			  .get(url, res => {
+				if (res.headers.location) resolve(res.headers.location);
+				else reject(new Error("Tiny URL not found!"));
+			  })
+			  .on("error", err => {
+				reject(err);
+			  });
+		  });
+	  }
 };


### PR DESCRIPTION
As requested in issue #18, this PR implements a resolver function that given a shortened link, it returns the original.

---

Usage example:
```
TinyURL.resolve("http://tinyurl.com/2tx").then(
  function(res) {
    console.log(res);
  },
  function(err) {
    console.log(err);
  }
);
```
Output:
`http://google.com`

---

**This function works with all available online link shorteners and not just [TinyURL](https://tinyurl.com/).**

---

Example:
```
TinyURL.resolve("http://cutt.ly/YeiWZhq").then(
  function(res) {
    console.log(res);
  },
  function(err) {
    console.log(err);
  }
);

```
Output:
`http://google.com`

---